### PR TITLE
Arch Linux gcc6 compile fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,14 +138,11 @@ METNO_IF_WITH([geotiff], [
     METNO_REQUIRE_C_LIBRARY([JPEG], [jpeg], [jpeglib.h], [jpeg_read_header])
     METNO_REQUIRE_C_LIBRARY([TIFF], [tiff], [tiff.h], [TIFFOpen], [${ZLIB_LIBS} ${JPEG_LIBS}])
   ])
-  AC_CHECK_HEADER([libgeotiff/geotiff.h], [break])
-  if test x"$ac_cv_header_libgeotiff_geotiff_h" == xyes
-  then
-    METNO_REQUIRE_C_LIBRARY([GEOTIFF], [geotiff], [libgeotiff/geotiff.h], [main], [${ZLIB_LIBS} ${TIFF_LIBS}])
-    GEOTIFF_CPPFLAGS="${GEOTIFF_CPPFLAGS} -DLIBGEOTIFF"
-  else
-    METNO_REQUIRE_C_LIBRARY([GEOTIFF], [geotiff], [geotiff/geotiff.h], [main], [${ZLIB_LIBS} ${TIFF_LIBS}])
-  fi
+  AC_CHECK_HEADERS(
+    [libgeotiff/geotiff.h geotiff/geotiff.h geotiff.h], [
+      METNO_REQUIRE_C_LIBRARY([GEOTIFF], [geotiff], [], [main], [${ZLIB_LIBS} ${TIFF_LIBS}])
+      break
+    ])
 ], [])
 METNO_WITH_CONDITIONAL([GEOTIFF], [geotiff])
 

--- a/src/diGlUtilities.cc
+++ b/src/diGlUtilities.cc
@@ -1,3 +1,4 @@
+#include <math.h>
 
 #include "diGlUtilities.h"
 

--- a/src/diPolyContouring.cc
+++ b/src/diPolyContouring.cc
@@ -114,7 +114,7 @@ class DianaPositionsList : public DianaPositions {
 public:
   DianaPositionsList(const DianaArrayIndex& index, const float* xpos, const float* ypos)
     : mIndex(index), mXpos(xpos), mYpos(ypos) { }
-  
+
   contouring::point_t position(size_t ix, size_t iy) const
     { const size_t i = mIndex(ix, iy); return contouring::point_t(mXpos[i], mYpos[i]); }
 
@@ -127,7 +127,7 @@ class DianaPositionsFormula : public DianaPositions {
 public:
   DianaPositionsFormula(const float* coeff)
     : cxy(coeff) { }
-  
+
   contouring::point_t position(size_t ix, size_t iy) const
     { const float x = cxy[0]+cxy[1]*ix+cxy[2]*iy;
       const float y = cxy[3]+cxy[4]*ix+cxy[5]*iy;
@@ -194,7 +194,7 @@ DianaLevelLog::DianaLevelLog(const std::vector<float>& levels)
   for (size_t i=0; i<levels.size(); ++i) {
      float l = levels[i];
     if (l > BASE or (l>0 and l<1)) {
-      const float logBl = log(l) / log(BASE), flogBl = logBl - floor(logBl);
+      const float logBl = log(l) / log(double(BASE)), flogBl = logBl - floor(logBl);
       l = pow(BASE, flogBl);
     }
     if (l >= 1 and l < BASE and (mLevels.empty() or l > mLevels.back()))
@@ -210,7 +210,7 @@ contouring::level_t DianaLevelLog::level_for_value(float value) const
     return UNDEF_LEVEL;
   if (value == 0)
     return UNDEF_LEVEL;
-  const double logBv = log(value)/log(BASE), ilogBv = floor(logBv);
+  const double logBv = log(value)/log(double(BASE)), ilogBv = floor(logBv);
   const double v_0_B = std::pow(BASE, logBv - ilogBv);
   const contouring::level_t l = DianaLevelList::level_for_value(v_0_B);
   return ilogBv*nlevels() + l;
@@ -287,10 +287,10 @@ public:
     : DianaFieldBase(levels, positions)
     , mIndex(index), mData(data)
     { }
-  
+
   virtual size_t nx() const
     { return mIndex.size_x(); }
-  
+
   virtual size_t ny() const
     { return mIndex.size_y(); }
 

--- a/src/miRaster/satgeotiff.cc
+++ b/src/miRaster/satgeotiff.cc
@@ -67,14 +67,18 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#ifdef LIBGEOTIFF
+#ifdef HAVE_GEOTIFF_GEOTIFF_H
+#include <geotiff/geotiff.h>
+#include <geotiff/geotiffio.h>
+#include <geotiff/geo_tiffp.h>
+#elif HAVE_LIBGEOTIFF_H
 #include <libgeotiff/geotiff.h>
 #include <libgeotiff/geotiffio.h>
 #include <libgeotiff/geo_tiffp.h>
 #else
-#include <geotiff/geotiff.h>
-#include <geotiff/geotiffio.h>
-#include <geotiff/geo_tiffp.h>
+#include <geotiff.h>
+#include <geotiffio.h>
+#include <geo_tiffp.h>
 #endif
 
 #include <tiffio.h>
@@ -118,7 +122,7 @@ int metno::GeoTiff::read_diana(const std::string& infile, unsigned char *image[]
   ginfo.zsize =1;
   // read header
   pal = head_diana(infile,ginfo);
-  
+
   METLIBS_LOG_DEBUG("Palette: " << pal);
 
   if(pal == -1)
@@ -137,9 +141,9 @@ int metno::GeoTiff::read_diana(const std::string& infile, unsigned char *image[]
 
   unsigned int tileWidth, tileLength;
   int tilesAcross=1, tilesDown=1;
-  
+
   short planar_config;   //Planar_Configuration 284 short (1 or 2)
-  
+
   tsample_t samplesperpixel, bitspersample;
   // Read image data into matrix.
 
@@ -231,7 +235,7 @@ int metno::GeoTiff::read_diana(const std::string& infile, unsigned char *image[]
       imageWidth  = ginfo.xsize;
       imageLength = ginfo.ysize;
       int tileSize = TIFFTileSize(in);
- 
+
       buf = _TIFFmalloc(tileSize);
 
       for (y = 0; y < imageLength; y += tileLength) {
@@ -309,7 +313,7 @@ int metno::GeoTiff::read_diana(const std::string& infile, unsigned char *image[]
         //ORIENTATION_TOPLEFT,
         0))
     {
-      METLIBS_LOG_ERROR("TIFFReadRGBAImageOriented (ORIENTATION_BOTLEFT) failed: size " <<  ginfo.xsize << "," << ginfo.ysize); 
+      METLIBS_LOG_ERROR("TIFFReadRGBAImageOriented (ORIENTATION_BOTLEFT) failed: size " <<  ginfo.xsize << "," << ginfo.ysize);
     }
     mImageCache->putInCache(file, (uint8_t*)image[0], size*4);
   }
@@ -320,7 +324,7 @@ int metno::GeoTiff::read_diana(const std::string& infile, unsigned char *image[]
 
 int metno::GeoTiff::head_diana(const std::string& infile, dihead &ginfo)
 {
- 
+
   METLIBS_LOG_TIME();
 
   int status;
@@ -352,14 +356,14 @@ int metno::GeoTiff::head_diana(const std::string& infile, dihead &ginfo)
   //    pmi= 3 : color palette
 
   status = TIFFGetField(in, TIFFTAG_PHOTOMETRIC, &pmi);
-  
-  METLIBS_LOG_DEBUG("TIFFGetField (TIFFTAG_PHOTOMETRIC) status: " << status << " pmi: " << pmi); 
-  
+
+  METLIBS_LOG_DEBUG("TIFFGetField (TIFFTAG_PHOTOMETRIC) status: " << status << " pmi: " << pmi);
+
   ginfo.pmi = pmi;
   if(pmi==3){
     status = TIFFGetField(in, TIFFTAG_COLORMAP, &red, &green, &blue);
-    
-    METLIBS_LOG_DEBUG("TIFFGetField (TIFFTAG_COLORMAP) status: " << status); 
+
+    METLIBS_LOG_DEBUG("TIFFGetField (TIFFTAG_COLORMAP) status: " << status);
 
     if (status != 1) {
       TIFFClose(in);
@@ -395,7 +399,7 @@ int metno::GeoTiff::head_diana(const std::string& infile, dihead &ginfo)
   METLIBS_LOG_DEBUG("TIFFGetField (TIFFTAG_DATETIME) status: " << status);
   if ((status == 1)&&(datetime != 0)) {
     METLIBS_LOG_DEBUG("datetime: " << datetime);
-    
+
     int hour,minute,day,month,year,sec;
     //Format hour:min day/month-year
     // Format 2009:11:09 10:30:00
@@ -918,4 +922,3 @@ short GeoTiff::selalg(const dto& d, const ucs& upos, const float& hmax, const fl
 
 
 #endif // end if 0
-

--- a/src/vcross_v2/VcrossQtPaint.cc
+++ b/src/vcross_v2/VcrossQtPaint.cc
@@ -29,7 +29,7 @@ void PaintWindArrow::makeArrowPrimitives(QVector<QLineF>& lines,
   const float KN5_SCALE = 0.6;
 
   const float ff = sqrtf(u*u + v*v);
-  if (ff <= 0.00001 or isnan(ff))
+  if (ff <= 0.00001 or std::isnan(ff))
     return;
 
   const util::WindArrowFeathers waf = util::countFeathers(ff);
@@ -145,7 +145,7 @@ void PaintVector::paintArrow(QPainter& painter, float px, float py, float ex, fl
 void PaintVector::paint(QPainter& painter, float u, float v, float px, float py) const
 {
   const float ff = sqrtf(u*u + v*v);
-  if (ff <= 0.00001 or isnan(ff))
+  if (ff <= 0.00001 or std::isnan(ff))
     return;
 
   QPen pen = painter.pen();

--- a/src/vcross_v2/VcrossQtPlot.cc
+++ b/src/vcross_v2/VcrossQtPlot.cc
@@ -659,7 +659,7 @@ void QtPlot::prepareYAxisRange()
       for (int p=0; p<np; ++p) {
         idx.set(H_COORD, p);
         const float zax_value = z_values->value(idx);
-        if (!isnan(zax_value)) {
+        if (!std::isnan(zax_value)) {
           have_z = true;
           vcross::util::minimaximize(yax_min, yax_max, zax_value);
         }
@@ -1507,7 +1507,7 @@ void QtPlot::plotDataArrow(QPainter& painter, OptionPlot_cp plot, const PaintArr
           and ((not xStepAuto) or (not paintedY) or (std::abs(py - lastY) >= autofactor*pa.size()));
       if (paintThisY) {
         const float wx = av0->value(idx_av0), wy = av1->value(idx_av1);
-        if (not (isnan(wx) or isnan(wy))) {
+        if (not (std::isnan(wx) or std::isnan(wy))) {
           pa.paint(painter, wx, wy, px, py);
           lastY = py;
           paintedY = true;
@@ -1595,7 +1595,7 @@ std::string QtPlot::plotDataExtremes(QPainter& painter, OptionPlot_cp plot)
         continue;
 
       const float v = absValue(plot, ix, iy, isTimeGraph());
-      if (isnan(v))
+      if (std::isnan(v))
         continue;
 
       if ((not have_max) or v > max_v) {
@@ -1621,7 +1621,7 @@ std::string QtPlot::plotDataExtremes(QPainter& painter, OptionPlot_cp plot)
     const QColor color(vcross::util::QC(plot->poptions.linecolour));
     painter.setPen(QPen(color, plot->poptions.linewidth));
     painter.setBrush(Qt::NoBrush);
-    
+
     const float R = 9*plot->poptions.extremeSize, D = R*sqrt(2)/2;
     if (have_min) {
       painter.drawEllipse(QPointF(min_px, min_py), R, R);


### PR DESCRIPTION
Fixes for compiling on an Arch Linux based system using gcc 6.2.1.
Arch Linux does not place GeoTIFF headers into a subdirectory but rather directly into /usr/include/.

Slightly simplified the configure.ac GeoTIFF header check through:

1. the usage of AC_CHECK_HEADERS() instead of AC_CHECK_HEADER()
2. the removal of the (seemingly superfluous) LIBGEOTIFF preprocessor define